### PR TITLE
Fix for nested models

### DIFF
--- a/packages/sequelize/hooks/after-find.hook.ts
+++ b/packages/sequelize/hooks/after-find.hook.ts
@@ -13,6 +13,9 @@ export function NestjsRosettaSequelizeAfterFind(instanceOrInstances: Model | Mod
         for (const key of Object.keys(instance["dataValues"])) {
             if (Reflect.getMetadata(TRANSLATION_COLUMN_METADATA_KEY, Object.getPrototypeOf(instance), key)) {
                 instance["dataValues"][key] = new TranslationObject(instance["dataValues"][key]);
+            } else if (instance["dataValues"][key]?.["dataValues"]) {
+                // Run the hook on nested models
+                NestjsRosettaSequelizeAfterFind(instance["dataValues"][key]);
             }
         }
     }

--- a/packages/sequelize/hooks/after-find.hook.ts
+++ b/packages/sequelize/hooks/after-find.hook.ts
@@ -13,7 +13,7 @@ export function NestjsRosettaSequelizeAfterFind(instanceOrInstances: Model | Mod
         for (const key of Object.keys(instance["dataValues"])) {
             if (Reflect.getMetadata(TRANSLATION_COLUMN_METADATA_KEY, Object.getPrototypeOf(instance), key)) {
                 instance["dataValues"][key] = new TranslationObject(instance["dataValues"][key]);
-            } else if (instance["dataValues"][key]?.["dataValues"]) {
+            } else if (Array.isArray(instance["dataValues"][key]) || typeof instance["dataValues"][key] === "object") {
                 // Run the hook on nested models
                 NestjsRosettaSequelizeAfterFind(instance["dataValues"][key]);
             }


### PR DESCRIPTION
The AfterFindHook was not running on nested models, so now we check if any of the dataValues has a dataValues, and if does, it means that it's a model, se we run the hook on it.