### PR TITLE
Implemented skip translation strategies

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -5,3 +5,5 @@ export * from "./interfaces/nestjs-rosetta-interceptor.config";
 export * from "./interceptors/nestjs-rosetta.interceptor";
 export * from "./models/translation-object.model";
 export * from "./decorators/skip-translations.decorator"
+export * from "./skip-translation-strategies/skip-translation-strategy";
+export * from "./skip-translation-strategies/type.skip-translation-strategy";

--- a/packages/core/interceptors/nestjs-rosetta.interceptor.ts
+++ b/packages/core/interceptors/nestjs-rosetta.interceptor.ts
@@ -23,7 +23,11 @@ export class NestjsRosettaInterceptor implements NestInterceptor {
             return next.handle();
         }
 
-        return next.handle().pipe(map((value) => this.transformValue(value, 0, config)));
+        return next.handle().pipe(map((value) => {
+            if (this.options.skipTranslationStrategies?.some(strategy => strategy.shouldSkip(value))) return value;
+
+            return this.transformValue(value, 0, config);
+        }));
     }
 
     private transformValue(value: any, depth: number, config: NestjsRosettaInterceptorConfig): any {

--- a/packages/core/interfaces/nestjs-rosetta.options.ts
+++ b/packages/core/interfaces/nestjs-rosetta.options.ts
@@ -1,7 +1,9 @@
 import { TranslationObjectProcessor } from "../processors/translation-object.processor";
+import { SkipTranslationStrategy } from "../skip-translation-strategies/skip-translation-strategy";
 
 export interface NestjsRosettaOptions {
     processors: TranslationObjectProcessor[];
     supportedLanguages: string[];
     fallbackLanguage: string;
+    skipTranslationStrategies?: SkipTranslationStrategy[];
 }

--- a/packages/core/nestjs-rosetta.module.ts
+++ b/packages/core/nestjs-rosetta.module.ts
@@ -10,9 +10,7 @@ import { Readable } from "stream";
 @Module({})
 export class NestjsRosettaModule {
     static readonly DEFAULT_SKIP_TRANSLATION_STRATEGIES = [
-        new TypeSkipTranslationStrategy(Buffer),
-        new TypeSkipTranslationStrategy(StreamableFile),
-        new TypeSkipTranslationStrategy(Readable),
+        new TypeSkipTranslationStrategy(Buffer, StreamableFile, Readable, Object),
     ];
 
     public static forRoot(options: NestjsRosettaOptions): DynamicModule {

--- a/packages/core/nestjs-rosetta.module.ts
+++ b/packages/core/nestjs-rosetta.module.ts
@@ -1,12 +1,23 @@
-import { DynamicModule, Module } from "@nestjs/common";
+import { DynamicModule, Module, StreamableFile } from "@nestjs/common";
 import { APP_INTERCEPTOR } from "@nestjs/core";
 import { NESTJS_ROSETTA_OPTIONS_TOKEN } from "./constants/constants";
 import { NestjsRosettaInterceptor } from "./interceptors/nestjs-rosetta.interceptor";
 import { NestjsRosettaOptions } from "./interfaces/nestjs-rosetta.options";
+import { TypeSkipTranslationStrategy } from "./skip-translation-strategies/type.skip-translation-strategy";
+import { Buffer } from "buffer";
+import { Readable } from "stream";
 
 @Module({})
 export class NestjsRosettaModule {
+    static readonly DEFAULT_SKIP_TRANSLATION_STRATEGIES = [
+        new TypeSkipTranslationStrategy(Buffer),
+        new TypeSkipTranslationStrategy(StreamableFile),
+        new TypeSkipTranslationStrategy(Readable),
+    ];
+
     public static forRoot(options: NestjsRosettaOptions): DynamicModule {
+        options.skipTranslationStrategies ??= NestjsRosettaModule.DEFAULT_SKIP_TRANSLATION_STRATEGIES;
+
         return {
             module: NestjsRosettaModule,
             providers: [

--- a/packages/core/skip-translation-strategies/skip-translation-strategy.ts
+++ b/packages/core/skip-translation-strategies/skip-translation-strategy.ts
@@ -1,0 +1,3 @@
+export abstract class SkipTranslationStrategy {
+    public abstract shouldSkip(value: any): boolean;
+}

--- a/packages/core/skip-translation-strategies/type.skip-translation-strategy.ts
+++ b/packages/core/skip-translation-strategies/type.skip-translation-strategy.ts
@@ -2,11 +2,14 @@ import { SkipTranslationStrategy } from "./skip-translation-strategy";
 import { Type } from "@nestjs/common";
 
 export class TypeSkipTranslationStrategy extends SkipTranslationStrategy {
-    constructor(private type: Type) {
+    private types: Type[];
+
+    constructor(...types: Type[]) {
         super();
+        this.types = types;
     }
 
     public override shouldSkip(value: any): boolean {
-        return value instanceof this.type;
+        return this.types.some(type => value instanceof type);
     }
 }

--- a/packages/core/skip-translation-strategies/type.skip-translation-strategy.ts
+++ b/packages/core/skip-translation-strategies/type.skip-translation-strategy.ts
@@ -1,0 +1,12 @@
+import { SkipTranslationStrategy } from "./skip-translation-strategy";
+import { Type } from "@nestjs/common";
+
+export class TypeSkipTranslationStrategy extends SkipTranslationStrategy {
+    constructor(private type: Type) {
+        super();
+    }
+
+    public override shouldSkip(value: any): boolean {
+        return value instanceof this.type;
+    }
+}


### PR DESCRIPTION
`SkipTranslationStrategies` can be used to dynamically skip the returned value.
For example, the `TypeSkipTranslationStrategy` is used to skip the translation of certain type (`Buffer`, `StreamableFile` and `Readable` by default).
It is possible to implement a custom strategy by extending the base class.

It didn't remove the `@SkipTranslations()` decorators, since they could still be useful.
