### PR TITLE
Fix mongoose null document

### DIFF
--- a/packages/mongoose/plugins/rosetta.plugin.ts
+++ b/packages/mongoose/plugins/rosetta.plugin.ts
@@ -19,6 +19,10 @@ function transformModel(docs: Model<any> | Model<any>[], schema: Schema) {
     }
 
     for (const doc of docs) {
+        if (doc === null || doc === undefined) {
+            continue;
+        }
+
         for (const key in schema.obj) {
             const obj = schema.obj[key];
             if (!obj["rosetta"]) {


### PR DESCRIPTION
Depending on the aggregation, the documents returned by the database can be null, but the plugin assumed that everything was not null.