### PR TITLE
Update  Peer dependency for rxjs and reflect-metadata version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "peerDependencies": {
         "@nestjs/common": "^10.0.0",
         "@nestjs/core": "^10.0.0",
-        "rxjs": "^7.5.5",
+        "rxjs": ">=7.5.5",
         "accept-language-parser": "^1.5.0",
         "reflect-metadata": "^0.1.13"
     },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "@nestjs/core": "^10.0.0",
         "rxjs": ">=7.5.5",
         "accept-language-parser": "^1.5.0",
-        "reflect-metadata": "^0.1.13"
+        "reflect-metadata": ">=0.1.13"
     },
     "devDependencies": {
         "@nestjs/common": "^10.2.7",
@@ -42,7 +42,7 @@
         "jest": "^29.7.0",
         "lerna": "^6.4.0",
         "mongoose": "^7.5.4",
-        "reflect-metadata": "^0.1.13",
+        "reflect-metadata": ">=0.1.13",
         "rxjs": "^7.8.0",
         "sequelize": "^6.33.0",
         "sequelize-typescript": "^2.1.5",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,7 +9,7 @@
         "@nestjs/common": "^10.2.0",
         "@nestjs/core": "^10.2.0",
         "reflect-metadata": "^0.1.13",
-        "rxjs": "^7.5.5"
+        "rxjs": ">=7.5.5"
     },
     "dependencies": {
         "accept-language-parser": "^1.5.0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,7 +8,7 @@
     "peerDependencies": {
         "@nestjs/common": "^10.2.0",
         "@nestjs/core": "^10.2.0",
-        "reflect-metadata": "^0.1.13",
+        "reflect-metadata": ">=0.1.13",
         "rxjs": ">=7.5.5"
     },
     "dependencies": {

--- a/packages/mongoose/package.json
+++ b/packages/mongoose/package.json
@@ -11,7 +11,7 @@
         "@nestjs/mongoose": ">=10.0.0",
         "@recursyve/nestjs-rosetta-core": ">=10.0.0-beta.23",
         "mongoose": ">=6.6.5 || >= 7.0.0",
-        "reflect-metadata": "^0.1.13"
+        "reflect-metadata": ">=0.1.13"
     },
     "devDependencies": {
         "@nestjs/common": "^10.2.7",

--- a/packages/sequelize/package.json
+++ b/packages/sequelize/package.json
@@ -10,7 +10,7 @@
         "@nestjs/core": ">=10.2.0",
         "@nestjs/sequelize": ">=10.0.0",
         "@recursyve/nestjs-rosetta-core": ">=10.0.0-beta.23",
-        "reflect-metadata": "^0.1.13",
+        "reflect-metadata": ">=0.1.13",
         "sequelize": "^6.33.0",
         "sequelize-typescript": "^2.1.5"
     },


### PR DESCRIPTION
The goal of this change is to soften the constrain on the npm package to be able to upgrade the library for other projets.

The only place it is used is in the file `nestjs-rosetta.interceptor.ts`:
```typescript
import { map, Observable } from "rxjs";
```